### PR TITLE
Fix broken links in navigation bar of F19 course page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,13 +22,13 @@ main_dropdown:
    title: Resources
    items:
      - title: Topics
-       url: /topic_list/
+       url: /topics/
      - title: Resources
-       url: /resource_list/
+       url: /resources/
      - title: Tutorials
-       url: /tutorial_list/
+       url: /tutorials/
      - title: Textbooks
-       url: /textbook_list/       
+       url: /textbooks/       
 
 offering_menus:
   -

--- a/_pages/exam_list.md
+++ b/_pages/exam_list.md
@@ -1,6 +1,6 @@
 ---
 title: Exams
-permalink: "/exam_list/"
+permalink: "/exam/"
 ---
 
 # {{site.course}}, {{site.quarter}}


### PR DESCRIPTION
The following fixes were made:
* Changed all URLs in the Resources dropdown to match current page permalinks
* Changed the permalink of the exam page to match the current permalink path name convention