### PR TITLE
Typo for one of the links in the lab instructions

### DIFF
--- a/_lab/lab05.md
+++ b/_lab/lab05.md
@@ -67,7 +67,7 @@ Also clone this repo as a "sibling" (i.e. side by side in the same directory) wi
 Your starter code will be your <tt>{{page.prev_num}}</tt> repo, with a small number of additional files from: <tt>{{page.starter_repo}}</tt>.  So we'll define a remote for your <tt>{{page.prev_num}}</tt> repo:
 
  
-<tt>git remote add {{page.prev-num}} git@github.com:{{page.github_org}}/{{page.prev_num}}-cgaucho1-ldelplaya22.git</tt>
+<tt>git remote add {{page.prev-num}} lab03 git@github.com:{{page.github_org}}/{{page.prev_num}}-cgaucho1-ldelplaya22.git</tt>
    
 Pull from your <tt>{{page.prev_num}}</tt> repo into your <tt>{{page.num}}</tt> repo, and then push to github.
 


### PR DESCRIPTION
(Originally from https://ucsb-cs56-f19.slack.com/archives/CNDUA1A91/p1571365492022400)

In the steps to setup the lab05 repo, the command to add lab03 as a remote is missing the name specifier before the url.